### PR TITLE
Measure resetter

### DIFF
--- a/frontend/companion-app/App.tsx
+++ b/frontend/companion-app/App.tsx
@@ -204,7 +204,7 @@ const styles = StyleSheet.create({
     padding: 10,
     backgroundColor: 'lightgray',
     width: '100%',
-    minHeight: 50
+    minHeight: 64
   },
   text_input: {
     backgroundColor: 'white',

--- a/frontend/companion-app/App.tsx
+++ b/frontend/companion-app/App.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, Text, View, SafeAreaView} from 'react-native'; // Imports s
 import React, { useEffect, useRef, useState } from 'react'; // Imports React and hooks
 import { OpenSheetMusicDisplay, Cursor } from 'opensheetmusicdisplay'; // Imports the OpenSheetMusicDisplay library for rendering sheet music
 import { Play_Button, Score_Select, Stop_Button, TimeStampBox} from './Components';
+import { MeasureSetBox } from './components/MeasureSetter';
 
 // Define the main application component
 export default function App() {
@@ -72,6 +73,7 @@ export default function App() {
             osm.render();
             console.log('Music XML loaded successfully'); // Log success message to console
             cursorRef.current = osm.cursor; // Pass reference to cursor
+            cursorRef.current.show(); // and never hide it.  it should always be visible
             cursorRef.current.CursorOptions = { ...cursorRef.current.CursorOptions, ... { "follow": true} }
           })
           .catch((error) => {
@@ -125,7 +127,10 @@ export default function App() {
         cursorPos={cursorPos} setCursorPos={setCursorPos} osdRef={osdRef}
         />
         <Stop_Button setPlaying={setPlaying} button_style={styles.button} text_style={styles.button_text}/>
-        <TimeStampBox timestamp={timestamp} setTimestamp={setTimestamp} style={styles.text_input}/>
+        <MeasureSetBox timestamp={timestamp} setTimestamp={setTimestamp} 
+          cursorRef={cursorRef} osdRef={osdRef} style={styles.button_wrapper}
+        />
+        {/* <TimeStampBox timestamp={timestamp} setTimestamp={setTimestamp} style={styles.text_input}/> */}
       </View>
 
       <div style={styles.scrollContainer}> {/* Container for scrolling the sheet music */}

--- a/frontend/companion-app/App.tsx
+++ b/frontend/companion-app/App.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef, useState } from 'react'; // Imports React and
 import { OpenSheetMusicDisplay, Cursor } from 'opensheetmusicdisplay'; // Imports the OpenSheetMusicDisplay library for rendering sheet music
 import { Play_Button, Score_Select, Stop_Button, TimeStampBox} from './Components';
 import { MeasureSetBox } from './components/MeasureSetter';
+import { Fraction } from 'opensheetmusicdisplay';
 
 // Define the main application component
 export default function App() {
@@ -28,7 +29,8 @@ export default function App() {
   const [playing, setPlaying] = useState(false);
   
   const [cursorPos, setCursorPos] = useState<number>(-1); // this and all features using it are to be deprecated
-  const [timestamp, setTimestamp] = useState<string>("0.0")
+  const [timestamp, setTimestamp] = useState<number>(0); // timestamp in seconds which the cursor attempts to approximate
+  const [cursorExactTimestamp, setCursorExactTimestamp] = useState<number>(0); // timestamp of the note the cursor is at
     
   const handleFileUpload = (file: File) => {
     const reader = new FileReader();
@@ -44,6 +46,9 @@ export default function App() {
     };
     reader.readAsText(file);
   };
+
+  const BPM = 100; // EDIT THESE AS APPROPRIATE
+  const TSD = 4;
 
   // useEffect hook to handle side effects (like loading music) after the component mounts
   // and when a piece is selected
@@ -90,28 +95,34 @@ export default function App() {
   // useEffect to update the time-stamp
   useEffect( () => {
     // move the cursor based on the timestamp!
-    if (cursorRef.current?.hidden) cursorRef.current?.show();
-        var ts = Number(timestamp); // the timestamp is a string rn bc it's in an input box
-        var ct = cursorRef.current?.Iterator.CurrentSourceTimestamp.RealValue; // cursor time
-        var nct; // new cursor time
-        var cpos = cursorPos; // pointless? update to cursor state
-        if (ct !== undefined) { // if the cursor does exist...
-            while (ct < ts && !(cursorRef.current?.Iterator.EndReached)) {
-                // cursorRef.current?.Iterator.moveToNext()
-                cursorRef.current?.next(); // Move it until we pass the timestamp (or reach the end)
-                cpos += 1;
-                nct = cursorRef.current?.Iterator.CurrentSourceTimestamp.RealValue
-                if (nct !== undefined) ct = nct;
-            }
-            if (!(cursorRef.current?.Iterator.EndReached)) {
-                // cursorRef.current?.Iterator.moveToPrevious()
-                cursorRef.current?.previous(); // Then if we haven't reached the end, move back
-                setCursorPos(cpos - 1);
-            }
-        }
-        if (osdRef.current !== undefined && osdRef.current?.Sheet !== undefined) {
-          osdRef.current.render();
-        }
+    let ct = cursorExactTimestamp; // current timestamp of cursor's note(s) in seconds
+    var dt;
+    if (cursorRef.current?.Iterator.CurrentSourceTimestamp !== undefined) {
+      var ts_meas = Fraction.createFromFraction(cursorRef.current?.Iterator.CurrentSourceTimestamp); // current timestamp of iterator as a fraction
+      var ts_start = Fraction.createFromFraction(ts_meas); // where iterator starts from, as a fraction
+
+      // while timestamp is less than desired, update it
+      while (ct < timestamp ) {
+        cursorRef.current?.Iterator.moveToNextVisibleVoiceEntry(false);
+        dt = Fraction.minus(cursorRef.current?.Iterator.CurrentSourceTimestamp, ts_meas);
+        // dt is a fraction indicating how much - in whole notes - the iterator moved
+                  
+        // // If we are using the active BPM and time signature in the given score, uncomment: 
+        // ct += 60 * dt.RealValue * cursorRef.current?.Iterator.CurrentMeasure.ActiveTimeSignature.Denominator / cursorRef.current?.Iterator.CurrentBpm
+        // // and remove the BPM and TSD arguments used in the below, and comment the below:
+        ct += 60 * dt.RealValue * TSD / BPM;
+        // // either way, the calculation is:
+        // 60 secs/min * dt wholes * time signature denominator (beats/whole) / BPM (beats/minute) yields seconds
+        ts_meas = Fraction.plus(ts_meas, dt);
+      }
+      cursorRef.current?.Iterator.moveToPreviousVisibleVoiceEntry(false);
+      setCursorExactTimestamp(cursorExactTimestamp + 60 * Fraction.minus(cursorRef.current?.Iterator.CurrentSourceTimestamp, ts_start).RealValue * TSD / BPM);
+      cursorRef.current?.update();
+    }  
+                
+    if (osdRef.current !== undefined && osdRef.current?.Sheet !== undefined) {
+      osdRef.current.render();
+    }
   }, [timestamp])
 
 
@@ -127,10 +138,12 @@ export default function App() {
         cursorPos={cursorPos} setCursorPos={setCursorPos} osdRef={osdRef}
         />
         <Stop_Button setPlaying={setPlaying} button_style={styles.button} text_style={styles.button_text}/>
-        <MeasureSetBox timestamp={timestamp} setTimestamp={setTimestamp} 
-          cursorRef={cursorRef} osdRef={osdRef} style={styles.button_wrapper}
+        <MeasureSetBox setTimestamp={setCursorExactTimestamp}
+          cursorRef={cursorRef}
+          text_input_style={styles.text_input} button_style={styles.button} button_text_style={styles.button_text} label_text_style={styles.label}
+          BPM={BPM} TSD={TSD}
         />
-        {/* <TimeStampBox timestamp={timestamp} setTimestamp={setTimestamp} style={styles.text_input}/> */}
+        <TimeStampBox timestamp={timestamp} setTimestamp={setTimestamp} style={styles.text_input}/>
       </View>
 
       <div style={styles.scrollContainer}> {/* Container for scrolling the sheet music */}
@@ -156,6 +169,9 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 20, // Set the font size for the title
     marginBottom: 20, // Add space below the title
+  },
+  label: {
+    fontSize: 12,
   },
   scrollContainer: {
     width: '100%', // Make the scroll container fill the width of the parent

--- a/frontend/companion-app/Components.tsx
+++ b/frontend/companion-app/Components.tsx
@@ -107,11 +107,11 @@ export function TimeStampBox( { timestamp, setTimestamp, style } :
     { timestamp: number, setTimestamp: (val: number) => void, style: ViewStyle }) {
     return(
         <View style={style}>
-            <Text>Old time stamp box:</Text>
+            <Text>Go to time in seconds live:</Text>
         <TextInput
             onChangeText={ (mytext) => { setTimestamp(Number(mytext)) } }
             value={String(timestamp)}
-            placeholder="useless placeholder"
+            placeholder="0"
             inputMode="numeric"
         />
         </View>

--- a/frontend/companion-app/Components.tsx
+++ b/frontend/companion-app/Components.tsx
@@ -104,12 +104,13 @@ export function Stop_Button( { setPlaying, button_style, text_style } :
 }
 
 export function TimeStampBox( { timestamp, setTimestamp, style } : 
-    { timestamp: string, setTimestamp: (text: string) => void, style: ViewStyle }) {
+    { timestamp: number, setTimestamp: (val: number) => void, style: ViewStyle }) {
     return(
         <View style={style}>
+            <Text>Old time stamp box:</Text>
         <TextInput
-            onChangeText={setTimestamp}
-            value={timestamp}
+            onChangeText={ (mytext) => { setTimestamp(Number(mytext)) } }
+            value={String(timestamp)}
             placeholder="useless placeholder"
             inputMode="numeric"
         />

--- a/frontend/companion-app/components/MeasureSetter.tsx
+++ b/frontend/companion-app/components/MeasureSetter.tsx
@@ -2,6 +2,7 @@ import { View, Text } from 'react-native';
 import { Pressable, TextInput, TextStyle, ViewStyle } from "react-native";
 import { MutableRefObject, useEffect,  useRef, useState } from 'react';
 import { OpenSheetMusicDisplay, Cursor } from 'opensheetmusicdisplay';
+import { Fraction } from 'opensheetmusicdisplay';
 
 export function MeasureSetBox( { cursorRef, osdRef, timestamp, setTimestamp, style } : 
     { cursorRef: MutableRefObject<Cursor | null>, osdRef: MutableRefObject<OpenSheetMusicDisplay | null>,
@@ -11,13 +12,18 @@ export function MeasureSetBox( { cursorRef, osdRef, timestamp, setTimestamp, sty
     const [needsReset, setNeedsReset] = useState<Boolean>(false)
     useEffect( () => {
         if (needsReset) {
-            console.log(cursorRef.current?.Iterator.CurrentMeasureIndex);
-            console.log(osdRef.current?.Sheet.DefaultStartTempoInBpm);
+            console.log(cursorRef.current?.Iterator.CurrentMeasure.ActiveTimeSignature);
+            console.log(cursorRef.current?.Iterator.CurrentBpm);
             // Where is the time signature?
-            let desired_index = Number(resetMeasure) - 1
+            let desired_index = Number(resetMeasure) - 1;
+            let ts_secs = 0;
+            let ts_meas = new Fraction(); // default value is 0 + 0/1, or 0
+            var dt: Fraction;
             cursorRef.current?.resetIterator()
             while (cursorRef.current?.Iterator.CurrentMeasureIndex !== undefined && cursorRef.current?.Iterator.CurrentMeasureIndex < desired_index) {
                 cursorRef.current?.Iterator.moveToNextVisibleVoiceEntry(false);
+                dt = Fraction.minus(cursorRef.current?.Iterator.CurrentSourceTimestamp, ts_meas);
+                ts_secs += dt.RealValue * cursorRef.current?.Iterator.CurrentBpm * cursorRef.current?.Iterator.CurrentMeasure.Duration.Denominator
             }
             cursorRef.current?.update();
             setNeedsReset(false);
@@ -33,7 +39,7 @@ export function MeasureSetBox( { cursorRef, osdRef, timestamp, setTimestamp, sty
             placeholder="useless placeholder"
             inputMode="numeric"
         />
-        <Pressable onPress={() => { setNeedsReset(true); }}>RESET</Pressable>
+        <Pressable onPress={() => { setNeedsReset(true); }}><Text>RESET</Text></Pressable>
         </View>
         
     )

--- a/frontend/companion-app/components/MeasureSetter.tsx
+++ b/frontend/companion-app/components/MeasureSetter.tsx
@@ -4,42 +4,57 @@ import { MutableRefObject, useEffect,  useRef, useState } from 'react';
 import { OpenSheetMusicDisplay, Cursor } from 'opensheetmusicdisplay';
 import { Fraction } from 'opensheetmusicdisplay';
 
-export function MeasureSetBox( { cursorRef, osdRef, timestamp, setTimestamp, style } : 
-    { cursorRef: MutableRefObject<Cursor | null>, osdRef: MutableRefObject<OpenSheetMusicDisplay | null>,
-        timestamp: string, setTimestamp: (text: string) => void, style: ViewStyle }) {
+export function MeasureSetBox( { cursorRef, setTimestamp, button_style, text_input_style, button_text_style, label_text_style, BPM, TSD } : 
+    { cursorRef: MutableRefObject<Cursor | null>, setTimestamp: (val: number) => void,
+        button_style: ViewStyle, text_input_style: ViewStyle, button_text_style: TextStyle, label_text_style: TextStyle,
+        BPM: number, TSD: number // Beats per minute and time signature denominator, respectively
+    }) {
     
+    const [needsReset, setNeedsReset] = useState<boolean>(false); // indicates whether a reset to start measure is occurring
     const [resetMeasure, setResetMeasure] = useState<string>("1")
-    const [needsReset, setNeedsReset] = useState<Boolean>(false)
+    
     useEffect( () => {
         if (needsReset) {
-            console.log(cursorRef.current?.Iterator.CurrentMeasure.ActiveTimeSignature);
-            console.log(cursorRef.current?.Iterator.CurrentBpm);
-            // Where is the time signature?
             let desired_index = Number(resetMeasure) - 1;
-            let ts_secs = 0;
-            let ts_meas = new Fraction(); // default value is 0 + 0/1, or 0
-            var dt: Fraction;
+            // // If we are using the active BPM and time signature in the given score, uncomment: 
+            // let ts_meas = new Fraction(); // default is 0 + 0/1 = 0
+            // let ts_secs = 0;
+            // var dt;
             cursorRef.current?.resetIterator()
             while (cursorRef.current?.Iterator.CurrentMeasureIndex !== undefined && cursorRef.current?.Iterator.CurrentMeasureIndex < desired_index) {
                 cursorRef.current?.Iterator.moveToNextVisibleVoiceEntry(false);
-                dt = Fraction.minus(cursorRef.current?.Iterator.CurrentSourceTimestamp, ts_meas);
-                ts_secs += dt.RealValue * cursorRef.current?.Iterator.CurrentBpm * cursorRef.current?.Iterator.CurrentMeasure.Duration.Denominator
+                // // If we are using the active BPM and time signature in the given score, uncomment: 
+                // dt = Fraction.minus(cursorRef.current?.Iterator.CurrentSourceTimestamp, ts_meas);
+                // // dt is a fraction indicating how much - in whole notes - the iterator moved
+                // ts_secs += 60 * dt.RealValue * cursorRef.current?.Iterator.CurrentMeasure.ActiveTimeSignature.Denominator / cursorRef.current?.Iterator.CurrentBpm
+                // ts_meas = Fraction.plus(ts_meas, dt);
             }
-            cursorRef.current?.update();
+            if (cursorRef.current?.Iterator.CurrentSourceTimestamp.RealValue !== undefined) {
+                // // If we are using the active BPM and time signature in the given score, REcomment: 
+                setTimestamp(60 * cursorRef.current?.Iterator.CurrentSourceTimestamp.RealValue * TSD / BPM)
+                // // If we are using the active BPM and time signature in the given score, uncomment: 
+                // setTimestamp(ts_secs);
+            }
+            // either way, the calculation is:
+            // 60 secs/min * dt wholes * time signature denominator (beats/whole) / BPM (beats/minute) yields seconds
             setNeedsReset(false);
+            cursorRef.current?.update();
         }
     }, [needsReset])
 
     return(
         <View>
-            <Text>Start measure:</Text>
+            <Text style={label_text_style}>Start measure:</Text>
         <TextInput
             onChangeText={setResetMeasure}
             value={resetMeasure}
             placeholder="useless placeholder"
             inputMode="numeric"
+            style={text_input_style}
         />
-        <Pressable onPress={() => { setNeedsReset(true); }}><Text>RESET</Text></Pressable>
+        <Pressable style={button_style} onPress={() => { setNeedsReset(true); }}>
+            <Text style={button_text_style}>RESET</Text>
+        </Pressable>
         </View>
         
     )

--- a/frontend/companion-app/components/MeasureSetter.tsx
+++ b/frontend/companion-app/components/MeasureSetter.tsx
@@ -1,0 +1,40 @@
+import { View, Text } from 'react-native';
+import { Pressable, TextInput, TextStyle, ViewStyle } from "react-native";
+import { MutableRefObject, useEffect,  useRef, useState } from 'react';
+import { OpenSheetMusicDisplay, Cursor } from 'opensheetmusicdisplay';
+
+export function MeasureSetBox( { cursorRef, osdRef, timestamp, setTimestamp, style } : 
+    { cursorRef: MutableRefObject<Cursor | null>, osdRef: MutableRefObject<OpenSheetMusicDisplay | null>,
+        timestamp: string, setTimestamp: (text: string) => void, style: ViewStyle }) {
+    
+    const [resetMeasure, setResetMeasure] = useState<string>("1")
+    const [needsReset, setNeedsReset] = useState<Boolean>(false)
+    useEffect( () => {
+        if (needsReset) {
+            console.log(cursorRef.current?.Iterator.CurrentMeasureIndex);
+            console.log(osdRef.current?.Sheet.DefaultStartTempoInBpm);
+            // Where is the time signature?
+            let desired_index = Number(resetMeasure) - 1
+            cursorRef.current?.resetIterator()
+            while (cursorRef.current?.Iterator.CurrentMeasureIndex !== undefined && cursorRef.current?.Iterator.CurrentMeasureIndex < desired_index) {
+                cursorRef.current?.Iterator.moveToNextVisibleVoiceEntry(false);
+            }
+            cursorRef.current?.update();
+            setNeedsReset(false);
+        }
+    }, [needsReset])
+
+    return(
+        <View>
+            <Text>Start measure:</Text>
+        <TextInput
+            onChangeText={setResetMeasure}
+            value={resetMeasure}
+            placeholder="useless placeholder"
+            inputMode="numeric"
+        />
+        <Pressable onPress={() => { setNeedsReset(true); }}>RESET</Pressable>
+        </View>
+        
+    )
+}


### PR DESCRIPTION
Added a feature to reset cursor to specified measure.  It works at first, and one can set the timestamp via the box after that.  It doesn't seem to work after the timestamp has been changed in the box - will look into that.  Play and stop buttons remain unrelated to the timestamp.