### PR TITLE
Fix for tied notes

### DIFF
--- a/backend/src/hmm_conversion/convert.py
+++ b/backend/src/hmm_conversion/convert.py
@@ -22,35 +22,39 @@ def convert(filepath: Path):
 
     for n in score.flatten().notes:
         for p in n.pitches:
-            solo.append(
-                "{:<15}\t{}\t{}\t{}\t{}".format(
-                    "{}+{}/{}".format(
-                        n.measureNumber,
-                        *((n.beat - 1.0) / n.beatDuration.quarterLength).as_integer_ratio(),
-                    ),
-                    "{}/{}".format(*(n.offset / 4.0).as_integer_ratio()),
-                    n.volume.velocity if n.volume.velocity is not None else 90,
-                    p.midi,
-                    1,  # note on
+            # if tie type = stop (end of tie) --> skip onset
+            if n.tie is None or n.tie.type != 'stop':
+                solo.append(
+                    "{:<15}\t{}\t{}\t{}\t{}".format(
+                        "{}+{}/{}".format(
+                            n.measureNumber,
+                            *((n.beat - 1.0) / n.beatDuration.quarterLength).as_integer_ratio(),
+                        ),
+                        "{}/{}".format(*(n.offset / 4.0).as_integer_ratio()),
+                        n.volume.velocity if n.volume.velocity is not None else 90,
+                        p.midi,
+                        1,  # note on
+                    )
                 )
-            )
-            solo.append(
-                "{:<15}\t{}\t{}\t{}\t{}".format(
-                    "{}+{}/{}".format(
-                        n.measureNumber,
-                        *(
-                            ((n.beat - 1.0) / n.beatDuration.quarterLength)
-                            + n.quarterLength / 4.0
-                        ).as_integer_ratio(),
-                    ),
-                    "{}/{}".format(
-                        *((n.offset + n.quarterLength) / 4.0).as_integer_ratio()
-                    ),
-                    n.volume.velocity if n.volume.velocity is not None else 90,
-                    p.midi,
-                    0,  # note off
+            # if tie type = start (start of tie) --> skip offset
+            if n.tie is None or n.tie.type != 'start':
+                solo.append(
+                    "{:<15}\t{}\t{}\t{}\t{}".format(
+                        "{}+{}/{}".format(
+                            n.measureNumber,
+                            *(
+                                ((n.beat - 1.0) / n.beatDuration.quarterLength)
+                                + n.quarterLength / 4.0
+                            ).as_integer_ratio(),
+                        ),
+                        "{}/{}".format(
+                            *((n.offset + n.quarterLength) / 4.0).as_integer_ratio()
+                        ),
+                        n.volume.velocity if n.volume.velocity is not None else 90,
+                        p.midi,
+                        0,  # note off
+                    )
                 )
-            )
 
     bar_path = Path(name).with_suffix(".bar")
     solo_path = Path(name).with_suffix(".solo")


### PR DESCRIPTION
Added if statements to consider tied notes, should be considered as one prolonged note (with 1 onset and offset) instead of two separate notes